### PR TITLE
Reset DONE status after a successful wait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ impl CtrlC {
             loop {
                 if !DONE.load(Ordering::Relaxed) {
                     let _ = CVAR.wait(MUTEX.lock().unwrap());
+                    DONE.store(false, Ordering::Relaxed);
                 }
                 user_handler();
             }


### PR DESCRIPTION
This appears to fix #3. I'm not sure, but it might also cause some signals to get dropped? Also I'm not sure what Ordering to use for this so I used `Relaxed` because that's what the reads/writes to `DONE` use.

So far I've only tested it in linux, but I hope to test it in windows too.