### PR TITLE
remove fn #[repr(C)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@ mod platform {
     use self::libc::signal;
     use std::sync::atomic::Ordering;
 
-    #[repr(C)]
     pub fn handler(_: c_int) {
         super::features::DONE.store(true, Ordering::Relaxed);
     }


### PR DESCRIPTION
```
$ rustc --version
rustc 1.8.0-dev (2d14b3920 2016-02-20)
```

```
   Compiling ctrlc v1.1.0
src/lib.rs:49:5: 49:15 error: attribute should be applied to struct or enum [E0517]
src/lib.rs:49     #[repr(C)]
                  ^~~~~~~~~~
src/lib.rs:49:5: 49:15 help: run `rustc --explain E0517` to see a detailed explanation
src/lib.rs:49:5: 49:15 error: attribute should be applied to struct or enum [E0517]
src/lib.rs:49     #[repr(C)]
                  ^~~~~~~~~~
src/lib.rs:49:5: 49:15 help: run `rustc --explain E0517` to see a detailed explanation
error: aborting due to previous error
```