### PR TITLE
Export straight functions rather than a singleton struct therewith

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,16 @@ A simple easy to use wrapper around Ctrl-C signal.
 ## Example usage
 ```rust
 extern crate ctrlc;
-use ctrlc::CtrlC;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 fn main() {
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
-    CtrlC::set_handler(move || {
+    ctrlc::set_handler(move || {
         r.store(false, Ordering::SeqCst);
     });
-	println!("Waiting for Ctrl-C...");
+    println!("Waiting for Ctrl-C...");
     while running.load(Ordering::SeqCst) {}
     println!("Got it! Exiting...");
 }

--- a/examples/readme_example.rs
+++ b/examples/readme_example.rs
@@ -8,14 +8,13 @@
 // according to those terms.
 
 extern crate ctrlc;
-use ctrlc::CtrlC;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 fn main() {
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
-    CtrlC::set_handler(move || {
+    ctrlc::set_handler(move || {
         r.store(false, Ordering::SeqCst);
     });
     println!("Waiting for Ctrl-C...");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,8 +13,7 @@
 // though you have set up Ctrl-C handler of your own.
 
 extern crate ctrlc;
-use ctrlc::CtrlC;
 fn main() {
-    CtrlC::set_handler(|| println!("Hello world!"));
+    ctrlc::set_handler(|| println!("Hello world!"));
     loop {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,13 @@
 //! # Example
 //! ```no_run
 //! extern crate ctrlc;
-//! use ctrlc::CtrlC;
 //! use std::sync::atomic::{AtomicBool, Ordering};
 //! use std::sync::Arc;
 //!
 //! fn main() {
 //!     let running = Arc::new(AtomicBool::new(true));
 //!     let r = running.clone();
-//!     CtrlC::set_handler(move || {
+//!     ctrlc::set_handler(move || {
 //!         r.store(false, Ordering::SeqCst);
 //!     });
 //!     println!("Waiting for Ctrl-C...");
@@ -73,49 +72,44 @@ mod platform {
 }
 use self::platform::*;
 
-pub struct CtrlC;
-impl CtrlC {
-    /// Sets up the signal handler for Ctrl-C using default polling rate of 100ms.
-    /// # Example
-    /// ```
-    /// # use ctrlc::CtrlC;
-    /// CtrlC::set_handler(|| println!("Hello world!"));
-    /// ```
-    pub fn set_handler<F>(user_handler: F)
-        where F: Fn() -> () + 'static + Send
-    {
-        CtrlC::set_handler_with_polling_rate(user_handler, time::Duration::from_millis(100));
-    }
+/// Sets up the signal handler for Ctrl-C using default polling rate of 100ms.
+/// # Example
+/// ```
+/// ctrlc::set_handler(|| println!("Hello world!"));
+/// ```
+pub fn set_handler<F>(user_handler: F)
+    where F: Fn() -> () + 'static + Send
+{
+    self::set_handler_with_polling_rate(user_handler, time::Duration::from_millis(100));
+}
 
-    /// Sets up the signal handler for Ctrl-C using a custom polling rate.
-    /// The polling rate is the amount of time the internal spinloop of CtrlC sleeps between
-    /// iterations. Because condition variables are not safe to use inside a signal handler,
-    /// CtrlC (from version 1.1.0) uses a spinloop and an atomic boolean instead.
-    ///
-    /// Normally you should use `set_handler` instead, but if the default rate of  100 milliseconds
-    /// is too fast or too slow for you, you can use this routine instead to set your own.
-    /// # Example
-    /// ```
-    /// # use std::time::Duration;
-    /// # use ctrlc::CtrlC;
-    /// CtrlC::set_handler_with_polling_rate(
-    ///     || println!("Hello world!"),
-    ///     Duration::from_millis(10)
-    /// );
-    /// ```
-    pub fn set_handler_with_polling_rate<F>(user_handler: F, polling_rate: time::Duration)
-        where F: Fn() -> () + 'static + Send
-    {
-        unsafe {
-            set_os_handler(handler);
-        }
-        thread::spawn(move || {
-            loop {
-                if DONE.compare_and_swap(true, false, Ordering::Relaxed) {
-                    user_handler();
-                }
-                thread::sleep(polling_rate);
-            }
-        });
+/// Sets up the signal handler for Ctrl-C using a custom polling rate.
+/// The polling rate is the amount of time the internal spinloop of CtrlC sleeps between
+/// iterations. Because condition variables are not safe to use inside a signal handler,
+/// CtrlC (from version 1.1.0) uses a spinloop and an atomic boolean instead.
+///
+/// Normally you should use `set_handler` instead, but if the default rate of  100 milliseconds
+/// is too fast or too slow for you, you can use this routine instead to set your own.
+/// # Example
+/// ```
+/// # use std::time::Duration;
+/// ctrlc::set_handler_with_polling_rate(
+///     || println!("Hello world!"),
+///     Duration::from_millis(10)
+/// );
+/// ```
+pub fn set_handler_with_polling_rate<F>(user_handler: F, polling_rate: time::Duration)
+    where F: Fn() -> () + 'static + Send
+{
+    unsafe {
+        set_os_handler(handler);
     }
+    thread::spawn(move || {
+        loop {
+            if DONE.compare_and_swap(true, false, Ordering::Relaxed) {
+                user_handler();
+            }
+            thread::sleep(polling_rate);
+        }
+    });
 }


### PR DESCRIPTION
The original export scheme was... curious, to say the least.