### PR TITLE
Implement std::error::Error for ctrlc::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl StdError for Error {
+impl std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Init(ref msg) => &msg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@
 //! }
 //! ```
 
+use std::error::Error as StdError;
+use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 use std::thread;
 
@@ -36,6 +38,22 @@ pub enum Error {
     Init(String),
     MultipleHandlers(String),
     SetHandler,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CtrlC Error: {}", self.description())
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Init(ref msg) => &msg,
+            Error::MultipleHandlers(ref msg) => &msg,
+            Error::SetHandler => "Error setting handler"
+        }
+}
 }
 
 #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@
 //! }
 //! ```
 
-use std::error::Error as StdError;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 use std::thread;
@@ -42,6 +41,8 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::error::Error;
+        
         write!(f, "CtrlC Error: {}", self.description())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use std::error::Error;
         
-        write!(f, "CtrlC Error: {}", self.description())
+        write!(f, "CtrlC error: {}", self.description())
     }
 }
 
@@ -54,7 +54,7 @@ impl std::error::Error for Error {
             Error::MultipleHandlers(ref msg) => &msg,
             Error::SetHandler => "Error setting handler"
         }
-}
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Started to use the crate in my project and noticed that `std::error::Errror` hadn't been implemented for `ctrlc::Error`. Consider this a workable first pass and let me know if you would like any changes to anything.

Thank you.