### PR TITLE
Update to nix 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/Detegr/rust-ctrlc"
 repository = "https://github.com/Detegr/rust-ctrlc.git"
 
 [dependencies]
-nix = "0.8"
+nix = "0.9.0"
 winapi = "0.2"
 kernel32-sys = "0.2"
 


### PR DESCRIPTION
current dependency nix 0.8.0 comes with bitflags 0.7 which is hard to compile on rust 0.21