### PR TITLE
Fix build on openbsd 6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/Detegr/rust-ctrlc.git"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.10"
+nix = "0.11"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }


### PR DESCRIPTION
The current version on crates.io is not building on openbsd and nix 0.11.0 includes a fix for openbsd 6.3. :)

If possible, could you please release a new version containing this patch?