### PR TITLE
Fix nix build failure on openbsd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/Detegr/rust-ctrlc.git"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.11"
+nix = "0.13"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,10 @@ mod signal;
 pub use signal::*;
 
 pub use error::Error;
-use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
-static INIT: AtomicBool = ATOMIC_BOOL_INIT;
+static INIT: AtomicBool = AtomicBool::new(false);
 
 /// Register signal handler for Ctrl-C.
 ///


### PR DESCRIPTION
This bumps the nix dependency and resolves the deprecation warning about ATOMIC_BOOL_INIT.

Resolves #48 