### PR TITLE
bump nix to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/Detegr/rust-ctrlc.git"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.13"
+nix = "0.14"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }


### PR DESCRIPTION
nix 0.14 contains fix for nix-rust/nix#1057

Without this arm builds are failing.