### PR TITLE
chore: no-change upgrade to nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ repository = "https://github.com/Detegr/rust-ctrlc.git"
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.14"
+nix = "0.16"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { version = "0.3", features = ["fileapi", "processenv", "winnt"] }
- 
+
 [features]
 termination = []
 


### PR DESCRIPTION
`nix` has been upgraded, but it's fully compatible with our (trivial) use.

Tested on Ubuntu 19.10.