### PR TITLE
Update nix to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Detegr/rust-ctrlc.git"
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.17"
+nix = "0.18"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }


### PR DESCRIPTION
`pipe2` is no longer available on macOS, so I implemented it manually using `pipe` and `fcntl` similar to how it was implemented in nix 0.17.