### PR TITLE
Migrate to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["os"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/Detegr/rust-ctrlc.git"
 exclude = ["/.travis.yml", "/appveyor.yml"]
+edition = "2018"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.18"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A simple easy to use wrapper around Ctrl-C signal.
 
 ## Example usage
 ```rust
-extern crate ctrlc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 

--- a/examples/issue_46_example.rs
+++ b/examples/issue_46_example.rs
@@ -1,4 +1,3 @@
-extern crate ctrlc;
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/examples/readme_example.rs
+++ b/examples/readme_example.rs
@@ -7,7 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate ctrlc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,11 @@
-use std;
+use crate::platform;
 use std::fmt;
 
 /// Ctrl-C error.
 #[derive(Debug)]
 pub enum Error {
     /// Signal could not be found from the system.
-    NoSuchSignal(::SignalType),
+    NoSuchSignal(crate::SignalType),
     /// Ctrl-C signal handler already registered.
     MultipleHandlers,
     /// Unexpected system error.
@@ -22,8 +22,8 @@ impl Error {
     }
 }
 
-impl From<::platform::Error> for Error {
-    fn from(e: ::platform::Error) -> Error {
+impl From<platform::Error> for Error {
+    fn from(e: platform::Error) -> Error {
         let system_error = std::io::Error::new(std::io::ErrorKind::Other, e);
         Error::System(system_error)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 //!
 //! # Example
 //! ```no_run
-//! extern crate ctrlc;
 //! use std::sync::atomic::{AtomicBool, Ordering};
 //! use std::sync::Arc;
 //!

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -7,10 +7,8 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate nix;
-
-use self::nix::unistd;
-use error::Error as CtrlcError;
+use crate::error::Error as CtrlcError;
+use nix::unistd;
 use std::os::unix::io::RawFd;
 
 static mut PIPE: (RawFd, RawFd) = (-1, -1);
@@ -32,7 +30,7 @@ extern "C" fn os_handler(_: nix::libc::c_int) {
 #[inline]
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 fn pipe2(flags: nix::fcntl::OFlag) -> nix::Result<(RawFd, RawFd)> {
-    use self::nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
+    use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
 
     let pipe = unistd::pipe()?;
 
@@ -76,8 +74,8 @@ fn pipe2(flags: nix::fcntl::OFlag) -> nix::Result<(RawFd, RawFd)> {
 ///
 #[inline]
 pub unsafe fn init_os_handler() -> Result<(), Error> {
-    use self::nix::fcntl;
-    use self::nix::sys::signal;
+    use nix::fcntl;
+    use nix::sys::signal;
 
     PIPE = pipe2(fcntl::OFlag::O_CLOEXEC)?;
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -7,17 +7,15 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate winapi;
-
-use self::winapi::ctypes::c_long;
-use self::winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
-use self::winapi::shared::ntdef::HANDLE;
-use self::winapi::um::consoleapi::SetConsoleCtrlHandler;
-use self::winapi::um::handleapi::CloseHandle;
-use self::winapi::um::synchapi::{ReleaseSemaphore, WaitForSingleObject};
-use self::winapi::um::winbase::{CreateSemaphoreA, INFINITE, WAIT_FAILED, WAIT_OBJECT_0};
 use std::io;
 use std::ptr;
+use winapi::ctypes::c_long;
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
+use winapi::shared::ntdef::HANDLE;
+use winapi::um::consoleapi::SetConsoleCtrlHandler;
+use winapi::um::handleapi::CloseHandle;
+use winapi::um::synchapi::{ReleaseSemaphore, WaitForSingleObject};
+use winapi::um::winbase::{CreateSemaphoreA, INFINITE, WAIT_FAILED, WAIT_OBJECT_0};
 
 /// Platform specific error type
 pub type Error = io::Error;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use platform;
+use crate::platform;
 
 /// A cross-platform way to represent Ctrl-C or program termination signal. Other
 /// signals/events are supported via `Other`-variant.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,12 +7,8 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate ctrlc;
-
 #[cfg(unix)]
 mod platform {
-    extern crate nix;
-
     use std::io;
 
     pub unsafe fn setup() -> io::Result<()> {
@@ -24,7 +20,7 @@ mod platform {
     }
 
     pub unsafe fn raise_ctrl_c() {
-        self::nix::sys::signal::raise(self::nix::sys::signal::SIGINT).unwrap();
+        nix::sys::signal::raise(nix::sys::signal::SIGINT).unwrap();
     }
 
     pub unsafe fn print(fmt: ::std::fmt::Arguments) {
@@ -36,19 +32,17 @@ mod platform {
 
 #[cfg(windows)]
 mod platform {
-    extern crate winapi;
-
     use std::io;
     use std::ptr;
 
-    use self::winapi::shared::minwindef::DWORD;
-    use self::winapi::shared::ntdef::{CHAR, HANDLE};
-    use self::winapi::um::consoleapi::{AllocConsole, GetConsoleMode};
-    use self::winapi::um::fileapi::WriteFile;
-    use self::winapi::um::handleapi::INVALID_HANDLE_VALUE;
-    use self::winapi::um::processenv::{GetStdHandle, SetStdHandle};
-    use self::winapi::um::winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE};
-    use self::winapi::um::wincon::{AttachConsole, FreeConsole, GenerateConsoleCtrlEvent};
+    use winapi::shared::minwindef::DWORD;
+    use winapi::shared::ntdef::{CHAR, HANDLE};
+    use winapi::um::consoleapi::{AllocConsole, GetConsoleMode};
+    use winapi::um::fileapi::WriteFile;
+    use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+    use winapi::um::processenv::{GetStdHandle, SetStdHandle};
+    use winapi::um::winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE};
+    use winapi::um::wincon::{AttachConsole, FreeConsole, GenerateConsoleCtrlEvent};
 
     /// Stores a piped stdout handle or a cache that gets
     /// flushed when we reattached to the old console.
@@ -63,7 +57,7 @@ mod platform {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
             match *self {
                 Output::Pipe(handle) => unsafe {
-                    use self::winapi::shared::ntdef::VOID;
+                    use winapi::shared::ntdef::VOID;
 
                     let mut n = 0u32;
                     if WriteFile(
@@ -135,9 +129,9 @@ mod platform {
     }
 
     unsafe fn get_stdout() -> io::Result<HANDLE> {
-        use self::winapi::um::fileapi::{CreateFileA, OPEN_EXISTING};
-        use self::winapi::um::handleapi::INVALID_HANDLE_VALUE;
-        use self::winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
+        use winapi::um::fileapi::{CreateFileA, OPEN_EXISTING};
+        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+        use winapi::um::winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
 
         let stdout = CreateFileA(
             "CONOUT$\0".as_ptr() as *const CHAR,


### PR DESCRIPTION
Since #69, the minimum Rust version supported by this crate is 1.36 (because [nix 0.18 use `std::mem::MaybeUninit`](https://github.com/nix-rust/nix/pull/1214) that stabilized in 1.36), so we can migrate to the 2018 edition without breakage.

(This patch was created primarily by running [`cargo fix --editon`](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html#updating-your-code-to-be-compatible-with-the-new-edition), removing needless `extern crate`, and removing `self::` prefix from external crate paths.)