### PR TITLE
Fix Travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ rust:
 env:
 matrix:
   include:
-    - rust: nightly
+    - rust: stable
       env: SYNTAX_CHECK=1
       install:
-        - cargo install --force rustfmt-nightly
+        - rustup component add rustfmt
       script:
         - cargo fmt -- --check
 


### PR DESCRIPTION
Travis CI seems failed on `master` due to `rustfmt` install failure: https://travis-ci.org/github/Detegr/rust-ctrlc/builds/734809619
This patch fixes that failure by installing stable `rustfmt` via `rustup` instead of installing `rustfmt-nightly` from the source.
(This will also hopefully reduce Travis CI's run time.)