### PR TITLE
add "readme"-key to Cargo.toml (for crates.io preview)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/Detegr/rust-ctrlc.git"
 exclude = ["/.travis.yml", "/appveyor.yml"]
 edition = "2018"
+readme = "README.md"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.20"


### PR DESCRIPTION
Right now there is no preview on crates.io: https://crates.io/crates/ctrlc

With this PR (and the next release that contains this change) crates.io will show the README.md as preview which will attract more users.