### PR TITLE
Update `nix` dep to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 readme = "README.md"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.22"
+nix = "0.23"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }


### PR DESCRIPTION
`nix:0.23` fixes a buffer overflow ([RUSTSEC-2021-0119](https://rustsec.org/advisories/RUSTSEC-2021-0119.html)), so earlier versions (transitively) break builds that use `ctrlc` alongside tools like `cargo audit`.