### PR TITLE
Fixed two warnings in the build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub fn set_handler<F>(mut user_handler: F) -> Result<(), Error>
 where
     F: FnMut() -> () + 'static + Send,
 {
-    if INIT.compare_and_swap(false, true, Ordering::SeqCst) {
+    if INIT.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).map_or_else(|e| e, |a| a) {
         return Err(Error::MultipleHandlers);
     }
 

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -99,6 +99,7 @@ pub unsafe fn init_os_handler() -> Result<(), Error> {
         signal::SigSet::empty(),
     );
 
+    #[allow(unused_variables)]
     let sigint_old = match signal::sigaction(signal::Signal::SIGINT, &new_action) {
         Ok(old) => old,
         Err(e) => return Err(close_pipe(e)),


### PR DESCRIPTION
1. Compare_and_swap was deprecated thus I changed it over to compare_exchange while retaining the same functionality.
2. Unused variable warning fixed.