### PR TITLE
Converted to a fully asynchronous implementation that is backwards compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ctrlc"
 version = "3.2.1"
-authors = ["Antti Keränen <detegr@gmail.com>"]
+authors = ["Antti Keränen <detegr@gmail.com>", "John Sharratt <johnathan.sharratt@gmail.com>"]
 description = "Easy Ctrl-C handler for Rust projects"
 documentation = "http://detegr.github.io/doc/ctrlc"
 homepage = "https://github.com/Detegr/rust-ctrlc"
@@ -13,6 +13,14 @@ exclude = ["/.travis.yml", "/appveyor.yml"]
 edition = "2018"
 readme = "README.md"
 
+[features]
+default = [ "tokio" ]
+termination = []
+
+[dependencies]
+tokio = { version = "^1", features = [ "macros", "rt", "sync", "time" ], optional = true }
+async-std = { version = "^1", features = [ "alloc", "attributes", "default" ], default-features = false, optional = true }
+
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
 
@@ -21,9 +29,6 @@ winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { version = "0.3", features = ["fileapi", "processenv", "winnt"] }
-
-[features]
-termination = []
 
 [[test]]
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,5 @@ winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { version = "0.3", features = ["fileapi", "processenv", "winnt"] }
 
-[[test]]
-harness = false
-name = "tests"
-path = "src/tests.rs"
+[dev-dependencies]
+rusty-fork = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # CtrlC
+
 [![Build Status](https://travis-ci.org/Detegr/rust-ctrlc.svg?branch=master)](https://travis-ci.org/Detegr/rust-ctrlc)
 [![Build status](https://ci.appveyor.com/api/projects/status/kwg1uu2w2aqn9ta9/branch/master?svg=true)](https://ci.appveyor.com/project/Detegr/rust-ctrlc/branch/master)
 
@@ -7,6 +8,7 @@ A simple easy to use wrapper around Ctrl-C signal.
 [Documentation](http://detegr.github.io/doc/ctrlc/)
 
 ## Example usage
+
 ```rust
 use std::sync::mpsc::channel;
 use ctrlc;
@@ -20,6 +22,35 @@ fn main() {
     println!("Waiting for Ctrl-C...");
     rx.recv().expect("Could not receive from channel.");
     println!("Got it! Exiting..."); 
+}
+```
+
+### Asynchronous support
+
+This library now supports asynchronous operation using either the tokio or async-std runtimes.
+
+The default is a slimmed down version of tokio that can run within or outside of a runtime context.
+Selecting the async-std is done using feature flags (e.g. --no-default-features --features async-std)
+
+```rust
+use ctrlc;
+
+#[cfg_attr(feature = "tokio", tokio::main(flavor = "current_thread"))]
+#[cfg_attr(feature = "async-std", async_std::main())]
+async fn main() {
+    #[cfg(feature = "tokio")]
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    #[cfg(feature = "async-std")]
+    let (tx, rx) = async_std::channel::bounded(1);
+
+    ctrlc::set_async_handler(async move {
+            tx.send(()).await.expect("Could not send signal on channel.");
+        })
+        .expect("Error setting Ctrl-C handler");
+
+    println!("Waiting for Ctrl-C...");
+    rx.recv().await.expect("Could not receive from channel.");
+    println!("Got it! Exiting...");
 }
 ```
 

--- a/examples/async_example.rs
+++ b/examples/async_example.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2015 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use ctrlc;
+
+#[cfg_attr(feature = "tokio", tokio::main(flavor = "current_thread"))]
+#[cfg_attr(feature = "async-std", async_std::main())]
+async fn main() {
+    #[cfg(feature = "tokio")]
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    #[cfg(feature = "async-std")]
+    let (tx, rx) = async_std::channel::bounded(1);
+
+    ctrlc::set_async_handler(async move {
+            tx.send(()).await.expect("Could not send signal on channel.");
+        })
+        .expect("Error setting Ctrl-C handler");
+
+    println!("Waiting for Ctrl-C...");
+    rx.recv().await.expect("Could not receive from channel.");
+    println!("Got it! Exiting...");
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
     NoSuchSignal(crate::SignalType),
     /// Ctrl-C signal handler already registered.
     MultipleHandlers,
+    /// The handler has exited.
+    NoHandler,
     /// Unexpected system error.
     System(std::io::Error),
 }
@@ -17,6 +19,7 @@ impl Error {
         match *self {
             Error::NoSuchSignal(_) => "Signal could not be found from the system",
             Error::MultipleHandlers => "Ctrl-C signal handler already registered",
+            Error::NoHandler => "The handler has exited",
             Error::System(_) => "Unexpected system error",
         }
     }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,6 +1,7 @@
 //! Helper routines for the asynchronous functions
 
 use std::future::Future;
+#[cfg(test)]
 use std::time::Duration;
 
 /// Spawns a background thread using which ever asynchronous runtime the library is built with
@@ -31,7 +32,7 @@ where T: Future + Send + 'static, T::Output: Send + 'static,
 }
 
 /// Safely executing blocking code using which ever asynchronous runtime the library is built with
-pub fn block_on<F>(mut task: F)
+pub fn spawn_block_on<F>(mut task: F)
 where F: FnMut() -> () + 'static + Send,
 {
     #[cfg(feature = "tokio")]
@@ -54,6 +55,7 @@ where F: FnMut() -> () + 'static + Send,
 }
 
 /// Executes a future with a specific timeout using which ever asynchronous runtime the library is built with
+#[cfg(test)]
 #[must_use = "this `Option` should be handled"]
 pub async fn timeout<F>(duration: Duration, future: F) -> Option<F::Output>
 where F: Future

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,0 +1,72 @@
+//! Helper routines for the asynchronous functions
+
+use std::future::Future;
+use std::time::Duration;
+
+/// Spawns a background thread using which ever asynchronous runtime the library is built with
+pub fn spawn<T>(future: T)
+where T: Future + Send + 'static, T::Output: Send + 'static,
+{
+    #[cfg(feature = "tokio")]
+    if tokio::runtime::Handle::try_current().is_ok() {
+        tokio::spawn(future);
+    } else {
+        std::thread::Builder::new()
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                rt.block_on(future);
+            })
+            .expect("failed to spawn thread");
+    }
+
+    #[cfg(feature = "async-std")]
+    std::thread::Builder::new()
+        .spawn(move || {
+            async_std::task::block_on(future);
+        })
+        .expect("failed to spawn thread");
+}
+
+/// Safely executing blocking code using which ever asynchronous runtime the library is built with
+pub fn block_on<F>(mut task: F)
+where F: FnMut() -> () + 'static + Send,
+{
+    #[cfg(feature = "tokio")]
+    if tokio::runtime::Handle::try_current().is_ok() {
+        tokio::task::spawn_blocking(move || {
+            task();
+        });
+        return;
+    }
+
+    #[cfg(feature = "async-std")]
+    if async_std::task::try_current().is_some() {
+        std::thread::Builder::new()
+            .spawn(task)
+            .expect("failed to spawn thread");
+        return;
+    }
+
+    task();
+}
+
+/// Executes a future with a specific timeout using which ever asynchronous runtime the library is built with
+#[must_use = "this `Option` should be handled"]
+pub async fn timeout<F>(duration: Duration, future: F) -> Option<F::Output>
+where F: Future
+{
+    #[cfg(feature = "tokio")]
+    return match tokio::time::timeout(duration, future).await {
+        Ok(a) => Some(a),
+        Err(_) => None
+    };
+
+    #[cfg(feature = "async-std")]
+    return match async_std::future::timeout(duration, future).await {
+        Ok(a) => Some(a),
+        Err(_) => None
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@
 //! 
 //! # Example
 //! ```no_run
-//! #![cfg(feature="tokio")] 
 //! #[cfg_attr(feature = "tokio", tokio::main(flavor = "current_thread"))]
 //! #[cfg_attr(feature = "async-std", async_std::main())]
 //! async fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,8 @@ mod error;
 mod platform;
 pub use platform::Signal;
 mod signal;
-pub mod helper;
+mod tests;
+pub(crate) mod helper;
 pub use signal::*;
 use std::future::Future;
 
@@ -122,7 +123,7 @@ pub fn set_handler<F>(user_handler: F) -> Result<(), Error>
 where F: FnMut() -> () + 'static + Send,
 {
     set_async_handler(async move {
-        block_on(user_handler);
+        spawn_block_on(user_handler);
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,29 @@
 //! Handling of `SIGTERM and SIGHUP` can be enabled with `termination` feature. If this is enabled,
 //! the handler specified by `set_handler()` will be executed for `SIGINT`, `SIGTERM` and `SIGHUP`.
 //!
+//! If you are running with a tokio or async_std runtime(s) you can use asynchronous handlers
+//! 
+//! # Example
+//! ```no_run
+//! #![cfg(feature="tokio")] 
+//! #[cfg_attr(feature = "tokio", tokio::main(flavor = "current_thread"))]
+//! #[cfg_attr(feature = "async-std", async_std::main())]
+//! async fn main() {
+//!     #[cfg(feature = "tokio")]
+//!     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+//!     #[cfg(feature = "async-std")]
+//!     let (tx, rx) = async_std::channel::bounded(1);
+//! 
+//!     ctrlc::set_async_handler(async move {
+//!             tx.send(()).await.expect("Could not send signal on channel.");
+//!         })
+//!         .expect("Error setting Ctrl-C handler");
+//! 
+//!     println!("Waiting for Ctrl-C...");
+//!     rx.recv().await.expect("Could not receive from channel.");
+//!     println!("Got it! Exiting...");
+//! }
+//! ```
 
 #[macro_use]
 
@@ -70,6 +93,13 @@ static INIT: AtomicBool = AtomicBool::new(false);
 /// # Example
 /// ```no_run
 /// ctrlc::set_handler(|| println!("Hello world!")).expect("Error setting Ctrl-C handler");
+/// ```
+/// 
+/// If you are using the tokio or async-std runtime(s) you can set an asynchronous handler instead
+/// 
+/// # Example
+/// ```no_run
+/// ctrlc::set_async_handler(async { println!("Hello world!"); }).expect("Error setting Ctrl-C handler");
 /// ```
 ///
 /// # Warning

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -13,8 +13,14 @@ mod unix;
 #[cfg(windows)]
 mod windows;
 
+mod other;
+
 #[cfg(unix)]
 pub use self::unix::*;
 
 #[cfg(windows)]
 pub use self::windows::*;
+
+#[cfg(not(unix))]
+#[cfg(not(windows))]
+pub use self::other::*;

--- a/src/platform/other/mod.rs
+++ b/src/platform/other/mod.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use crate::error::Error as CtrlcError;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Platform specific error type
+pub type Error = std::io::Error;
+
+/// Platform specific signal type
+#[derive(Debug)]
+pub struct Signal {
+}
+
+#[derive(Debug, Default)]
+pub struct WaitForCtrlC {
+}
+
+impl Future
+for WaitForCtrlC {
+    type Output = Result<(), CtrlcError>;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}
+
+/// Register os signal handler.
+///
+/// Must be called before calling [`block_ctrl_c()`](fn.block_ctrl_c.html)
+/// and should only be called once.
+///
+/// # Errors
+/// Will return an error if a system error occurred.
+///
+#[allow(dead_code)]
+#[inline]
+pub fn init_os_handler() -> Result<WaitForCtrlC, Error>
+{
+    let ret = WaitForCtrlC::default();
+    Ok(ret)
+}
+

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -141,10 +141,7 @@ pub unsafe fn init_os_handler() -> Result<impl Future<Output=Result<(), CtrlcErr
                 let mut aio = AioCb::from_mut_slice( PIPE.0, 0, &mut buf[..], 0, SigevNotify::SigevNone, LioOpcode::LIO_NOP);
                 aio.read()?;
                 while aio.error() == Err(nix::errno::Errno::EINPROGRESS) {
-                    #[cfg(feature = "tokio")]
-                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-                    #[cfg(not(feature = "tokio"))]
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    crate::helper::sleep(std::time::Duration::from_millis(10)).await;
                 }
                 match aio.aio_return() {
                     Ok(1) => break,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -275,9 +275,21 @@ fn test_set_handler()
     }
 }
 
+fn test_set_async_handler_wrapper()
+{
+    #[cfg(feature = "tokio")]
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        runtime.block_on(test_set_async_handler());
+    }
 
-#[cfg_attr(feature = "tokio", tokio::main(flavor = "current_thread"))]
-#[cfg_attr(feature = "async-std", async_std::main())]
+    #[cfg(feature = "async-std")]
+    async_std::task::block_on(test_set_async_handler());
+}
+
 async fn test_set_async_handler()
 {
     #[cfg(feature = "tokio")]
@@ -347,7 +359,7 @@ rusty_fork_test! {
             (default)(info);
         }));
 
-        run_tests!(test_set_async_handler);
+        run_tests!(test_set_async_handler_wrapper);
 
         platform::cleanup().unwrap();
     }


### PR DESCRIPTION
I've converted this library to fully support asynchronous operations with the following capabilities

- fully backwards compatible, as in synchronous code that uses this library will still work.
- created support for the two main asynchronous runtimes (tokio and async-std)
- the users runtime of choice is selected via features toggles (tokio, async-std)
- defaults to a barebones dependency on tokio
- detects if a runtime is present or not, if its not present the library will run its only mini runtime
- added an asynchronous example
- now compiles properly on target=wasm32-wasi
- when using tokio can run as a single threaded runtime (important for browsers)

Tested on unix and wasm