### PR TITLE
add haiku support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 readme = "README.md"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.24", default-features = false, features = ["fs", "signal"]}
+nix = { version = "0.24", git = "https://github.com/nix-rust/nix", rev = "b0ab5573ea0a0df48053743d451cbdd9e3df7f68", default-features = false, features = ["fs", "signal"]}
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -26,9 +26,9 @@ extern "C" fn os_handler(_: nix::libc::c_int) {
     }
 }
 
-// pipe2(2) is not available on macOS or iOS, so we need to use pipe(2) and fcntl(2)
+// pipe2(2) is not available on macOS, iOS or Haiku, so we need to use pipe(2) and fcntl(2)
 #[inline]
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(any(target_os = "ios", target_os = "macos", target_os = "haiku"))]
 fn pipe2(flags: nix::fcntl::OFlag) -> nix::Result<(RawFd, RawFd)> {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
 
@@ -59,7 +59,7 @@ fn pipe2(flags: nix::fcntl::OFlag) -> nix::Result<(RawFd, RawFd)> {
 }
 
 #[inline]
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "haiku")))]
 fn pipe2(flags: nix::fcntl::OFlag) -> nix::Result<(RawFd, RawFd)> {
     unistd::pipe2(flags)
 }


### PR DESCRIPTION
hello,

the following changes adds compilation support for haiku. note that this relies on a more recent mainline of the nix dependency in order for this to be able to compile. 

a sample run is included below:

```
> uname -a
Haiku shredder 1 hrev56098 May 13 2022 08:04:13 x86_64 x86_64 Haiku


> cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.30s
     Running unittests (target/debug/deps/ctrlc-924088b04a373e44)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running src/tests.rs (target/debug/deps/tests-01b40067d85964c8)

test tests::test_set_handler ... ok

   Doc-tests ctrlc

running 2 tests
test src/lib.rs - set_handler (line 68) - compile ... ok
test src/lib.rs - (line 25) - compile ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
```