### PR TITLE
Migrate from `winapi` to `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ readme = "README.md"
 nix = { version = "0.25", default-features = false, features = ["fs", "signal"]}
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "winbase"] }
+windows-sys = { version = "0.42", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_Console"] }
 
 [target.'cfg(windows)'.dev-dependencies]
-winapi = { version = "0.3", features = ["fileapi", "processenv", "winnt"] }
+windows-sys = { version = "0.42", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_IO", "Win32_System_SystemServices", "Win32_System_Console"] }
 
 [features]
 termination = []


### PR DESCRIPTION
- Implemented #85 

Most function calls and their signatures stayed the same. Only some types changed.