### PR TITLE
Migrate Unix implementation to signal-hook-registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26", default-features = false, features = ["fs", "signal"]}
+signal-hook-registry = { version = "1.4.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_Console"] }
@@ -29,3 +30,5 @@ termination = []
 harness = false
 name = "tests"
 path = "src/tests.rs"
+
+[dependencies]

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -102,9 +102,7 @@ pub unsafe fn init_os_handler() -> Result<(), Error> {
     }
 
     // Register the handler.
-    let res = unsafe {
-        signal_hook_registry::register(nix::libc::SIGINT, os_handler)
-    };
+    let res = unsafe { signal_hook_registry::register(nix::libc::SIGINT, os_handler) };
 
     #[allow(unused_variables)]
     let sigint_id = match res {
@@ -114,13 +112,14 @@ pub unsafe fn init_os_handler() -> Result<(), Error> {
 
     #[cfg(feature = "termination")]
     {
-        let sigterm_id = match unsafe { signal_hook_registry::register(nix::libc::SIGTERM, os_handler) } { 
-            Ok(old) => old,
-            Err(_e) => {
-                signal_hook_registry::unregister(sigint_id);
-                return Err(close_pipe(nix::Error::EINVAL));
-            }
-        };
+        let sigterm_id =
+            match unsafe { signal_hook_registry::register(nix::libc::SIGTERM, os_handler) } {
+                Ok(old) => old,
+                Err(_e) => {
+                    signal_hook_registry::unregister(sigint_id);
+                    return Err(close_pipe(nix::Error::EINVAL));
+                }
+            };
         match unsafe { signal_hook_registry::register(nix::libc::SIGHUP, os_handler) } {
             Ok(_) => {}
             Err(_e) => {


### PR DESCRIPTION
Closes #97 by migrating the Unix backend to signal-hook-registry.

To avoid a breaking change the `signal-hook-registry` errors are translated to `EINVAL`, since that's what they usually are anyways.