### PR TITLE
unix: Restore old handler when returning MultipleHandlers

### DIFF
--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -114,6 +114,7 @@ pub unsafe fn init_os_handler() -> Result<(), Error> {
         Err(e) => return Err(close_pipe(e)),
     };
     if sigint_old.handler() != signal::SigHandler::SigDfl {
+        signal::sigaction(signal::Signal::SIGINT, &sigint_old).unwrap();
         return Err(close_pipe(nix::Error::EEXIST));
     }
 
@@ -128,6 +129,7 @@ pub unsafe fn init_os_handler() -> Result<(), Error> {
         };
         if sigterm_old.handler() != signal::SigHandler::SigDfl {
             signal::sigaction(signal::Signal::SIGINT, &sigint_old).unwrap();
+            signal::sigaction(signal::Signal::SIGTERM, &sigterm_old).unwrap();
             return Err(close_pipe(nix::Error::EEXIST));
         }
         let sighup_old = match signal::sigaction(signal::Signal::SIGHUP, &new_action) {
@@ -141,6 +143,7 @@ pub unsafe fn init_os_handler() -> Result<(), Error> {
         if sighup_old.handler() != signal::SigHandler::SigDfl {
             signal::sigaction(signal::Signal::SIGINT, &sigint_old).unwrap();
             signal::sigaction(signal::Signal::SIGTERM, &sigterm_old).unwrap();
+            signal::sigaction(signal::Signal::SIGHUP, &sighup_old).unwrap();
             return Err(close_pipe(nix::Error::EEXIST));
         }
     }


### PR DESCRIPTION
It seems reasonable to try to restore the original handler, before returning `MultopleHandlers` on Unix.
Aligns with the logic for the case when `sigaction` fails - the code is trying to restore old handlers for any previously affected signals.

I could not figure out how to check this behavior in the test.
`sigaction` is supposed to report the current handler without updating it, if passed `NULL`.
From https://man7.org/linux/man-pages/man2/sigaction.2.html:

    If act is non-NULL, the new action for signal signum is installed
    from act.  If oldact is non-NULL, the previous action is saved in
    oldact.

Not sure if this is true for other Unixes.
But [`nix::sys::signal::sigaction`](https://docs.rs/nix/latest/nix/sys/signal/fn.sigaction.html) does not seem to allow this particular usage, as it will always allocate and pass a non-NULL `act` value.