### PR TITLE
Bump to nix 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 rust-version = "1.63.0"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.26", default-features = false, features = ["fs", "signal"]}
+nix = { version = "0.27", default-features = false, features = ["fs", "signal"]}
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_Security", "Win32_System_Console"] }


### PR DESCRIPTION
This pulls in https://github.com/nix-rust/nix/pull/2049 and thus which will unlock https://github.com/rust-lang/rust/pull/111769.

If you merge this can you please then cut a new patch release? :pray: 