### PR TITLE
Fix build error on macOS

### DIFF
--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -42,6 +42,7 @@ fn pipe2(flags: nix::fcntl::OFlag) -> nix::Result<(RawFd, RawFd)> {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
 
     let pipe = unistd::pipe()?;
+    let pipe = (pipe.0.into_raw_fd(), pipe.1.into_raw_fd());
 
     let mut res = Ok(0);
 


### PR DESCRIPTION
Since v3.4.3 (https://github.com/Detegr/rust-ctrlc/pull/114, cc @saethlin), this crate failed to build on macOS (and iOS, Haiku, etc.)

Fixes #115

```
error[E0308]: mismatched types
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.3/src/platform/unix/mod.rs:50:33
    |
50  |             .and_then(|_| fcntl(pipe.0, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)))
    |                           ----- ^^^^^^ expected `i32`, found `OwnedFd`
    |                           |
    |                           arguments to this function are incorrect
    |
note: function defined here
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.28.0/src/fcntl.rs:600:8
    |
600 | pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
    |        ^^^^^

error[E0308]: mismatched types
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.3/src/platform/unix/mod.rs:51:33
    |
51  |             .and_then(|_| fcntl(pipe.1, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)));
    |                           ----- ^^^^^^ expected `i32`, found `OwnedFd`
    |                           |
    |                           arguments to this function are incorrect
    |
note: function defined here
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.28.0/src/fcntl.rs:600:8
    |
600 | pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
    |        ^^^^^

error[E0308]: mismatched types
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.3/src/platform/unix/mod.rs:[56](https://github.com/taiki-e/cargo-no-dev-deps/actions/runs/8218859730/job/22476165326#step:8:57):33
    |
56  |             .and_then(|_| fcntl(pipe.0, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)))
    |                           ----- ^^^^^^ expected `i32`, found `OwnedFd`
    |                           |
    |                           arguments to this function are incorrect
    |
note: function defined here
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.28.0/src/fcntl.rs:600:8
    |
600 | pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
    |        ^^^^^

error[E0308]: mismatched types
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.3/src/platform/unix/mod.rs:[57](https://github.com/taiki-e/cargo-no-dev-deps/actions/runs/8218859730/job/22476165326#step:8:58):33
    |
57  |             .and_then(|_| fcntl(pipe.1, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)));
    |                           ----- ^^^^^^ expected `i32`, found `OwnedFd`
    |                           |
    |                           arguments to this function are incorrect
    |
note: function defined here
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.28.0/src/fcntl.rs:600:8
    |
600 | pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
    |        ^^^^^

error[E0308]: mismatched types
  --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.3/src/platform/unix/mod.rs:61:21
   |
61 |         Ok(_) => Ok(pipe),
   |                  -- ^^^^ expected `(i32, i32)`, found `(OwnedFd, OwnedFd)`
   |                  |
   |                  arguments to this enum variant are incorrect
   |
   = note: expected tuple `(i32, i32)`
              found tuple `(OwnedFd, OwnedFd)`
help: the type constructed contains `(OwnedFd, OwnedFd)` due to the type of the argument passed
  --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.3/src/platform/unix/mod.rs:61:18
   |
61 |         Ok(_) => Ok(pipe),
   |                  ^^^----^
   |                     |
   |                     this argument influences the type of `Ok`
note: tuple variant defined here
  --> /rustc/2d24fe[59](https://github.com/taiki-e/cargo-no-dev-deps/actions/runs/8218859730/job/22476165326#step:8:60)1f30386d6d5fc2bb941c78d7266bf10f/library/core/src/result.rs:506:5

error[E0308]: mismatched types
    --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.3/src/platform/unix/mod.rs:63:35
     |
63   |             let _ = unistd::close(pipe.0);
     |                     ------------- ^^^^^^ expected `i32`, found `OwnedFd`
     |                     |
     |                     arguments to this function are incorrect
     |
note: function defined here
    --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.28.0/src/unistd.rs:1087:8
     |
1087 | pub fn close(fd: RawFd) -> Result<()> {
     |        ^^^^^

error[E0308]: mismatched types
    --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ctrlc-3.4.3/src/platform/unix/mod.rs:[64](https://github.com/taiki-e/cargo-no-dev-deps/actions/runs/8218859730/job/22476165326#step:8:65):35
     |
64   |             let _ = unistd::close(pipe.1);
     |                     ------------- ^^^^^^ expected `i32`, found `OwnedFd`
     |                     |
     |                     arguments to this function are incorrect
     |
note: function defined here
    --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.28.0/src/unistd.rs:1087:8
     |
1087 | pub fn close(fd: RawFd) -> Result<()> {
     |        ^^^^^
```