### PR TITLE
Do not crash on thread spawn error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,12 +131,7 @@ where
     F: FnMut() + 'static + Send,
 {
     unsafe {
-        match platform::init_os_handler(overwrite) {
-            Ok(_) => {}
-            Err(err) => {
-                return Err(err.into());
-            }
-        }
+        platform::init_os_handler(overwrite)?;
     }
 
     thread::Builder::new()
@@ -147,7 +142,7 @@ where
             }
             user_handler();
         })
-        .expect("failed to spawn thread");
+        .map_err(Error::System)?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR proposes to allow handling errors on spawning a thread by users. By this change, user applications can determine what to do when `Ctrl+C` hook could not be set:

- Do some clean up before exiting
- Just ignore setting Ctrl+C hook and continue

I know that Rust provides an escape hatch `std::panic::catch_unwind`, but it is only available when `panic = "abort"` and not an idiomatic error handling.