### PR TITLE
Ability to remove handlers, and ability to add `FnOnce` handlers instead of `FnMut`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ harness = false
 name = "issue_97"
 path = "tests/main/issue_97.rs"
 
+[[test]]
+harness = false
+name = "deinit"
+path = "tests/main/deinit.rs"
+
 [dev-dependencies]
 signal-hook = "0.3"
 

--- a/src/block_outcome.rs
+++ b/src/block_outcome.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BlockOutcome {
+    Awaited,
+    HandlerRemoved,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     MultipleHandlers,
     /// Unexpected system error.
     System(std::io::Error),
+    /// Handler was removed
+    HandlerRemoved,
 }
 
 impl Error {
@@ -18,6 +20,7 @@ impl Error {
             Error::NoSuchSignal(_) => "Signal could not be found from the system",
             Error::MultipleHandlers => "Ctrl-C signal handler already registered",
             Error::System(_) => "Unexpected system error",
+            Error::HandlerRemoved => "Handler was removed",
         }
     }
 }

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -162,6 +162,7 @@ pub unsafe fn init_os_handler(overwrite: bool) -> Result<(), Error> {
     Ok(())
 }
 
+#[allow(dead_code)]
 pub unsafe fn deinit_os_handler() -> Result<(), Error> {
     use nix::sys::signal;
 
@@ -181,6 +182,7 @@ pub unsafe fn deinit_os_handler() -> Result<(), Error> {
     Ok(())
 }
 
+#[allow(dead_code)]
 pub unsafe fn is_handler_init() -> bool {
     return PIPE.0 != -1 && PIPE.1 != -1;
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -8,7 +8,10 @@
 // according to those terms.
 
 use std::io;
+use std::io::ErrorKind;
 use std::ptr;
+
+
 use windows_sys::Win32::Foundation::{CloseHandle, BOOL, HANDLE, WAIT_FAILED, WAIT_OBJECT_0};
 use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
 use windows_sys::Win32::System::Threading::{
@@ -21,40 +24,94 @@ pub type Error = io::Error;
 /// Platform specific signal type
 pub type Signal = u32;
 
-const MAX_SEM_COUNT: i32 = 255;
-static mut SEMAPHORE: HANDLE = 0 as HANDLE;
+const MAX_SEM_COUNT: i32 = 65535;
 const TRUE: BOOL = 1;
 const FALSE: BOOL = 0;
 
-unsafe extern "system" fn os_handler(_: u32) -> BOOL {
-    // Assuming this always succeeds. Can't really handle errors in any meaningful way.
-    ReleaseSemaphore(SEMAPHORE, 1, ptr::null_mut());
-    TRUE
+#[derive(Debug, Clone, Copy)]
+pub struct OsHandler {
+    semaphore: HANDLE,
 }
 
-/// Register os signal handler.
+static mut HANDLER: Option<OsHandler> = None;
+
+unsafe extern "system" fn os_handler(_: u32) -> BOOL {
+    if let Some(handler) = HANDLER {
+        // Assuming this always succeeds. Can't really handle errors in any meaningful way.
+        ReleaseSemaphore(handler.semaphore, 1, ptr::null_mut());
+        TRUE
+    } else {
+        // We have no handler set. Not sure how the hell this function was even called then.
+        // But okay, just mark this as not handled (FALSE).
+        FALSE
+    }
+}
+
+/// Register OS signal handler.
 ///
 /// Must be called before calling [`block_ctrl_c()`](fn.block_ctrl_c.html)
 /// and should only be called once.
 ///
 /// # Errors
 /// Will return an error if a system error occurred.
-///
 #[inline]
-pub unsafe fn init_os_handler(_overwrite: bool) -> Result<(), Error> {
-    SEMAPHORE = CreateSemaphoreA(ptr::null_mut(), 0, MAX_SEM_COUNT, ptr::null());
-    if SEMAPHORE.is_null() {
+pub unsafe fn init_os_handler(overwrite: bool) -> Result<(), Error> {
+    if is_handler_init() {
+        if !overwrite {
+            return Err(ErrorKind::AlreadyExists.into())
+        } else {
+            deinit_os_handler()?;
+        }
+    }
+    assert!(!is_handler_init());
+
+    let semaphore = CreateSemaphoreA(ptr::null_mut(), 0, MAX_SEM_COUNT, ptr::null());
+    if semaphore.is_null() {
         return Err(io::Error::last_os_error());
     }
 
+    
+    // Remove OUR handlers if those exist
+    // It does not make sense to have multiple of same(!) OS handlers added.
+    let mut handlers_removed = 0;
+    while SetConsoleCtrlHandler(Some(os_handler), FALSE) == TRUE {
+        handlers_removed += 1;
+    }
+    if handlers_removed > 0 {
+        // This does not directly 
+        eprintln!(
+            "[ctrlc] Somehow {handlers_removed} other OS {} of `ctrlc` was added before. Probably a bug.", 
+            if handlers_removed == 1 { "handler" } else { "handlers" }
+        );
+    }
+
+    // Set our custom handler
     if SetConsoleCtrlHandler(Some(os_handler), TRUE) == FALSE {
         let e = io::Error::last_os_error();
-        CloseHandle(SEMAPHORE);
-        SEMAPHORE = 0 as HANDLE;
+        CloseHandle(semaphore);
         return Err(e);
     }
 
+    HANDLER = Some(OsHandler { semaphore });
+
     Ok(())
+}
+
+/// Unregisters OS signal handler set by [`ctrlc::platform::init_os_handler`].
+#[inline]
+pub unsafe fn deinit_os_handler() -> Result<(), Error> {
+    if let Some(handler) = HANDLER {
+        HANDLER = None;
+        CloseHandle(handler.semaphore);
+        SetConsoleCtrlHandler(Some(os_handler), FALSE); // Remove the handler callbalk
+        return Ok(());
+    }
+    Err(ErrorKind::NotFound.into())
+}
+
+pub unsafe fn is_handler_init() -> bool {
+    #[allow(static_mut_refs)]
+    return HANDLER.is_some();
 }
 
 /// Blocks until a Ctrl-C signal is received.
@@ -66,7 +123,9 @@ pub unsafe fn init_os_handler(_overwrite: bool) -> Result<(), Error> {
 ///
 #[inline]
 pub unsafe fn block_ctrl_c() -> Result<(), Error> {
-    match WaitForSingleObject(SEMAPHORE, INFINITE) {
+    let handler = HANDLER.ok_or::<Error>(ErrorKind::NotFound.into())?;
+
+    match WaitForSingleObject(handler.semaphore, INFINITE) {
         WAIT_OBJECT_0 => Ok(()),
         WAIT_FAILED => Err(io::Error::last_os_error()),
         ret => Err(io::Error::new(

--- a/tests/main/deinit.rs
+++ b/tests/main/deinit.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2023 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+#[macro_use]
+mod harness;
+use harness::{platform, run_harness};
+
+use std::sync::{atomic::{AtomicUsize, Ordering}, Arc};
+use std::time::Duration;
+
+fn interrupt_and_wait() {
+    unsafe { platform::raise_ctrl_c(); }
+    std::thread::sleep(Duration::from_millis(10));
+}
+
+fn test_deinit() {
+    let total_fires = Arc::new(AtomicUsize::new(0));
+    let fires = 0;
+
+    // 1. First handler
+    let handle = ctrlc::set_handler_once({
+        let total_fires = total_fires.clone();
+        move || {
+            total_fires.fetch_add(1, Ordering::Relaxed);
+            fires + 1
+        }
+    }).unwrap();
+    interrupt_and_wait();
+
+    // First unwrap for thread join, second one to `Option` because handler can be removed without firing.
+    let fires = handle.join().unwrap().unwrap(); 
+    assert_eq!(fires, 1);
+    assert_eq!(total_fires.load(Ordering::Relaxed), 1);
+
+    assert!(ctrlc::remove_all_handlers().is_err()); // This handler should be already removed after firing once.
+
+    // 2. Second handler
+    let handle = ctrlc::set_handler_once(|| 42).unwrap();
+    interrupt_and_wait();
+
+    assert_eq!(handle.join().unwrap().unwrap(), 42);
+    assert_eq!(total_fires.load(Ordering::Relaxed), 1);
+
+    assert!(ctrlc::remove_all_handlers().is_err()); // This handler should be already removed after firing once.
+
+    // 3. Test with a non-once handler
+    ctrlc::set_handler({
+        let total_fires = total_fires.clone();
+        move || {
+            total_fires.fetch_add(1, Ordering::Relaxed);
+        }
+    }).unwrap();
+    interrupt_and_wait();
+    interrupt_and_wait();
+    interrupt_and_wait();
+    interrupt_and_wait();
+    interrupt_and_wait();
+
+    assert_eq!(total_fires.load(Ordering::Relaxed), 6);
+    
+    ctrlc::remove_all_handlers().unwrap();
+
+    // 4. First handler again
+    let handle = ctrlc::set_handler_once({
+        let total_fires = total_fires.clone();
+        move || {
+            total_fires.fetch_add(1, Ordering::Relaxed);
+            fires + 1
+        }
+    }).unwrap();
+    interrupt_and_wait();
+
+    let fires = handle.join().unwrap().unwrap();
+
+    assert_eq!(fires, 2);
+    assert_eq!(total_fires.load(Ordering::Relaxed), 7);
+
+    assert!(ctrlc::remove_all_handlers().is_err()); // This handler should be already removed after firing once.
+}
+
+fn tests() {
+    run_tests!(test_deinit);
+}
+
+fn main() {
+    run_harness(tests);
+}


### PR DESCRIPTION
Changes:
1. Added `set_handler_once()`, `try_set_handler_once()` that accept `FnOnce() -> T` instead of FnMut. Those variants return whatever `FnOnce` returns via thread handle.
2. Made all handler setting function return `JoinHandle<_>` in order to be able to track threads, and get values from `FnOnce`.
3. Added function `remove_all_handlers()`. It deinitializes the OS signal handler and stops all awaiting ctrl+c handlers. `FnOnce`, after running once, automatically calls this.

Also, added a test `tests/main/deinit.rs` that shows and tests this behaviour.

Reasons, why I propose to add this:
- Had a usecase where I needed an interrupt handler to use `tokio::sync::oneshot::Channel` just once.
- Had a usecase where I needed to separately track two sequential interrupts.

Even if this PR will not be approved - would like to know whats wrong, to get some feedback.