### PR TITLE
Add try_set_scoped_handler: Scoped Ctrl-C Handler for Non-'static Closures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ path = "tests/main/mod.rs"
 
 [[test]]
 harness = false
+name = "mod_scoped"
+path = "tests/main/mod_scoped.rs"
+
+[[test]]
+harness = false
 name = "issue_97"
 path = "tests/main/issue_97.rs"
 

--- a/tests/main/mod_scoped.rs
+++ b/tests/main/mod_scoped.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 CtrlC developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+#[macro_use]
+mod harness;
+use harness::{platform, run_harness};
+
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    thread,
+};
+
+fn test_set_scoped_handler() {
+    let flag = AtomicBool::new(false);
+    thread::scope(|s| {
+        ctrlc::try_set_scoped_handler(s, || {
+            flag.store(true, Ordering::SeqCst);
+            true
+        })
+        .unwrap();
+
+        unsafe {
+            platform::raise_ctrl_c();
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert!(flag.load(Ordering::SeqCst));
+
+        match ctrlc::try_set_scoped_handler(s, || true) {
+            Err(ctrlc::Error::MultipleHandlers) => {}
+            ret => panic!("{:?}", ret),
+        }
+    })
+}
+
+fn tests() {
+    run_tests!(test_set_scoped_handler);
+}
+
+fn main() {
+    run_harness(tests);
+}


### PR DESCRIPTION
First of all, thank you for providing such an excellent crate. It has been incredibly helpful in the development of my own CLI tools!

---

This PR introduces a new function, try_set_scoped_handler, that enables setting a scoped Ctrl-C (SIGINT) signal handler using a std::thread::Scope. Unlike the existing set_handler and try_set_handler APIs, this version allows the use of non-'static closures, making it possible to reference stack-local state without requiring heap allocations or synchronization primitives like Arc.

# Motivation

The existing signal handler APIs require 'static closures, which limits their flexibility—especially in multi-threaded code where state is short-lived and scoped. This new function is particularly useful in structured concurrency scenarios (e.g., with thread::scope), where signal handling logic only needs to live within a temporary thread scope.

# Highlights
- Scoped lifetime support: The handler can reference variables that do not outlive the thread scope.
- Automatic de-registration: The handler can signal that it is finished by returning true, allowing the scope to exit cleanly.
- Error on multiple registrations: Consistent with the existing API, only one handler (scoped or static) may be installed at any time.

# Example
```rust
use std::sync::atomic::{AtomicBool, Ordering};
use std::thread;

let flag = AtomicBool::new(false);
thread::scope(|s| {
    ctrlc::try_set_scoped_handler(s, || {
        flag.store(true, Ordering::SeqCst);
        true
    }).unwrap();

    // Perform scoped work...
});
```

# Safety and Semantics
- The handler must eventually return true to allow the scope to complete.
- This function ensures that signal handling remains single-registration and safe within a scoped thread context.

# Limitations
- Only one scoped or static handler may be registered at a time.
- The scoped handler cannot be replaced, even if it finishes execution.